### PR TITLE
Iterative decoding with annotations

### DIFF
--- a/datasets/pcfg/data_generation.py
+++ b/datasets/pcfg/data_generation.py
@@ -1,7 +1,6 @@
 """ Generating training and test files for iterative decoding on PCFG.
 """
 
-from absl import app
 import numpy as np
 import re
 
@@ -118,10 +117,10 @@ def generate_intermediate_tasks(source_line, target_line):
   last_task = intermediate_tasks.pop()
   intermediate_tasks.append(last_task + ' END')
 
-  return intermediate_tasks
+  return intermediate_tasks, len(operations)
 
 
-def main(argv: Sequence[str]):
+def main():
     
     # Generating training data.
     with open(data_path + 'train.src') as file:
@@ -133,7 +132,7 @@ def main(argv: Sequence[str]):
     out_file_tgt = open(data_path + 'it_dec_train.tgt', 'w') 
     
     for in_line, out_line in zip(train_input_lines, train_output_lines):
-      int_tasks = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
+      int_tasks, _ = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
       for i in range(len(int_tasks) - 1):
         out_file_src.write(int_tasks[i] + '\n')
         out_file_tgt.write(int_tasks[i + 1] + '\n')
@@ -149,26 +148,31 @@ def main(argv: Sequence[str]):
     
     out_file_src = open(data_path + 'it_dec_val.src', 'w')
     out_file_tgt = open(data_path + 'it_dec_val.tgt', 'w')
-    
     out_file_src_dec = open(data_path + 'it_dec_test.src', 'w')
     out_file_tgt_dec = open(data_path + 'it_dec_test.tgt', 'w')
+    ops_file = open(data_path + 'it_dec_test.ops', 'w')
     
     ratio = 0.1 # ratio of test samples to store in the val set
     count = 0
     for in_line, out_line in zip(test_input_lines, test_output_lines):
       if count < ratio * len(test_input_lines):
-        int_tasks = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
+        int_tasks, _ = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
         for i in range(len(int_tasks) - 1):
           out_file_src.write(int_tasks[i] + '\n')
           out_file_tgt.write(int_tasks[i + 1] + '\n')
       else:
         out_file_src_dec.write(in_line)
         out_file_tgt_dec.write(out_line.strip('\n') + ' END\n')
+        _ , nb_ops = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
+        ops_file.write(str(nb_ops) + '\n')
       count += 1
     
     out_file_src.close()
     out_file_tgt.close()
+    out_file_src_dec.close()
+    out_file_tgt_dec.close()
+    ops_file.close()
     
     
 if __name__ == '__main__':
-  app.run(main)
+  main()

--- a/datasets/pcfg/data_generation.py
+++ b/datasets/pcfg/data_generation.py
@@ -22,11 +22,12 @@ def generate_intermediate_tasks(source_line, target_line):
    
   Returns:
     A list of strings where each string corresponds to an intermediate decoding 
-    task. The last string is always the final output + 'END'. For example:
+    task, and the number of operations involved in the task (int). The last 
+    string is always the final output + 'END'. For example:
     
     ["swap_first_last copy remove_second E18 E15 Q6 , P15 L18 X10 I15 Y14",
     "swap_first_last copy E18 E15 Q6", "swap_first_last E18 E15 Q6",
-    "Q6 E15 E18 END"]
+    "Q6 E15 E18 END"] , 3
    
   Raises:
     ValueError: Output and target strings do not match.
@@ -128,17 +129,17 @@ def main():
     with open(data_path + 'train.tgt') as file:
       train_output_lines = file.readlines()
     
-    out_file_src = open(data_path + 'it_dec_train.src', 'w')
-    out_file_tgt = open(data_path + 'it_dec_train.tgt', 'w') 
+    out_file_src_train = open(data_path + 'it_dec_train.src', 'w')
+    out_file_tgt_train = open(data_path + 'it_dec_train.tgt', 'w') 
     
     for in_line, out_line in zip(train_input_lines, train_output_lines):
       int_tasks, _ = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
       for i in range(len(int_tasks) - 1):
-        out_file_src.write(int_tasks[i] + '\n')
-        out_file_tgt.write(int_tasks[i + 1] + '\n')
+        out_file_src_train.write(int_tasks[i] + '\n')
+        out_file_tgt_train.write(int_tasks[i + 1] + '\n')
     
-    out_file_src.close()
-    out_file_tgt.close()
+    out_file_src_train.close()
+    out_file_tgt_train.close()
     
     # Generating val and test data.
     with open(data_path + 'test.src') as file:
@@ -146,11 +147,11 @@ def main():
     with open(data_path + 'test.tgt') as file:
       test_output_lines = file.readlines()
     
-    out_file_src = open(data_path + 'it_dec_val.src', 'w')
-    out_file_tgt = open(data_path + 'it_dec_val.tgt', 'w')
-    out_file_src_dec = open(data_path + 'it_dec_test.src', 'w')
-    out_file_tgt_dec = open(data_path + 'it_dec_test.tgt', 'w')
-    ops_file = open(data_path + 'it_dec_test.ops', 'w')
+    out_file_src_validation = open(data_path + 'it_dec_val.src', 'w')
+    out_file_tgt_validation = open(data_path + 'it_dec_val.tgt', 'w')
+    out_file_src_test = open(data_path + 'it_dec_test.src', 'w')
+    out_file_tgt_test = open(data_path + 'it_dec_test.tgt', 'w')
+    out_file_ops_test = open(data_path + 'it_dec_test.ops', 'w')
     
     ratio = 0.1 # ratio of test samples to store in the val set
     count = 0
@@ -158,20 +159,20 @@ def main():
       if count < ratio * len(test_input_lines):
         int_tasks, _ = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
         for i in range(len(int_tasks) - 1):
-          out_file_src.write(int_tasks[i] + '\n')
-          out_file_tgt.write(int_tasks[i + 1] + '\n')
+          out_file_src_validation.write(int_tasks[i] + '\n')
+          out_file_tgt_validation.write(int_tasks[i + 1] + '\n')
       else:
-        out_file_src_dec.write(in_line)
-        out_file_tgt_dec.write(out_line.strip('\n') + ' END\n')
+        out_file_src_test.write(in_line)
+        out_file_tgt_test.write(out_line.strip('\n') + ' END\n')
         _ , nb_ops = generate_intermediate_tasks(in_line.strip('\n'), out_line.strip('\n'))
-        ops_file.write(str(nb_ops) + '\n')
+        out_file_ops_test.write(str(nb_ops) + '\n')
       count += 1
     
-    out_file_src.close()
-    out_file_tgt.close()
-    out_file_src_dec.close()
-    out_file_tgt_dec.close()
-    ops_file.close()
+    out_file_src_validation.close()
+    out_file_tgt_validation.close()
+    out_file_src_test.close()
+    out_file_tgt_test.close()
+    out_file_ops_test.close()
     
     
 if __name__ == '__main__':

--- a/model/configs/default.py
+++ b/model/configs/default.py
@@ -58,6 +58,10 @@ def get_config():
 
   # Max prediction loops for prediction dataset.
   config.num_predict_loops = 20
+  # Whether to use annotated number of operations to limit number of loops.
+  config.use_annotations = True
+  # Extra loops in addition to annotations.
+  config.extra_loops = 2
 
   # Base learning rate.
   config.learning_rate = 0.0625
@@ -106,6 +110,8 @@ def get_config():
   config.save_checkpoints = True
   # Whether to restore from existing model checkpoints.
   config.restore_checkpoints = True
+  # Just do prediction from saved checkpoint.
+  config.just_do_pred = True
 
   # Save a checkpoint every these number of steps.
   config.checkpoint_every_steps = 5_000

--- a/model/input_pipeline.py
+++ b/model/input_pipeline.py
@@ -285,18 +285,20 @@ def preprocess_pcfg_data(dataset,
   dataset = dataset.repeat(num_epochs)
 
   if pack_examples:
-    dataset = pack_dataset(dataset, max_length)
+    dataset = pack_dataset(dataset, max_length, keys = ["inputs", "targets"])
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
   else:  # simple (static-shape) padded batching
     dataset = dataset.padded_batch(
         batch_size,
         padded_shapes={
             'inputs': max_length,
-            'targets': max_length
+            'targets': max_length,
+            'op': ()
         },
         padding_values={
             'inputs': 0,
-            'targets': 0
+            'targets': 0,
+            'op': 0,
         },
         drop_remainder=drop_remainder)
 

--- a/model/input_pipeline.py
+++ b/model/input_pipeline.py
@@ -285,7 +285,7 @@ def preprocess_pcfg_data(dataset,
   dataset = dataset.repeat(num_epochs)
 
   if pack_examples:
-    dataset = pack_dataset(dataset, max_length, keys = ["inputs", "targets"])
+    dataset = pack_dataset(dataset, max_length, keys = ['inputs', 'targets'])
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
   else:  # simple (static-shape) padded batching
     dataset = dataset.padded_batch(


### PR DESCRIPTION
**Updated data_generation.py to output number of ops:** data_generation.py now produces an .ops file for the it_dec_test split containing the number of operations in each input sequence of the iterative decoding test split. The number of operations is used to inform the number of prediction loops necessary to decode the iterative decoding test samples.

**Updated train.py to use annotations in iterative decoding:** see config.use_annotations. Other changes include: including the possibility to add extra prediction loops (to the number of loops obtained from the data), see config.extra_loops; printing wrong predictions instead of random predictions; saving list of predictions in a pickle file; adding the possibility of using a saved model to only perform predictions, see config.just_do_pred.

**Updated default.py:** to include flags use_annotations (use annotated number of operations to inform the number of prediction loops at test time), extra_loops (number of loops in addition to those obtained from annotations) and just_do_pred (only do predictions from a saved model).

**Updated input_pipeline.py to handle annotations**
