### PR TITLE
luanaruiz9: model adapted for cartesian product dataset

### DIFF
--- a/model/configs/default_cartesian.py
+++ b/model/configs/default_cartesian.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Flax Authors.
+# Copyright 2021 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,10 +68,10 @@ def get_config():
   # Whether to copy previous output
   config.copy_output = False
 
-  config.end_token = '[END]'
-  config.in_out_token = '[SEP2]'
-  config.sep_token = '[SEP]'
-  config.end_iter_token = '[ENDITER]'
+  config.end_token = "[END]"
+  config.in_out_token = "[SEP2]"
+  config.sep_token = "[SEP]"
+  config.end_iter_token = "[ENDITER]"
 
   # Base learning rate.
   config.learning_rate = 0.0625

--- a/model/configs/default_cartesian.py
+++ b/model/configs/default_cartesian.py
@@ -1,0 +1,136 @@
+# Copyright 2021 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Default Hyperparameter configuration."""
+
+import ml_collections
+
+
+def get_config():
+  """Get the default hyperparameter configuration."""
+  config = ml_collections.ConfigDict()
+
+  # Path to load or store sentencepiece vocab file.
+  config.vocab_path = None
+
+  # Vocabulary size if `vocab_path` is not given.
+  config.vocab_size = 26
+  config.max_corpus_chars = 10**7
+
+  # Name of cartesian dataset to use.
+  config.dataset_name = "cartesian_token_short_input"
+  config.train_split = "train"
+
+  # Optional name of cartesian dataset to use for evaluation.
+  config.eval_dataset_name = None
+  config.eval_split = "test_easy"
+  config.predict_split = "test_easy"
+
+  # Per device batch size for training.
+  config.per_device_batch_size = 64
+
+  # Beam size for inference.
+  config.beam_size = 4
+
+  config.num_train_steps = 5_000
+
+  # Number of steps to take during evaluation.
+  config.num_eval_steps = 1
+  # Number of steps to generate predictions.
+  # -1 will use the whole eval dataset.
+  config.num_predict_steps = 2
+  # Number of steps to take during evaluation of training set.
+  config.num_eval_train_steps = 5
+  # Number of steps to generate predictions on the training set.
+  # -1 will use the whole training dataset.
+  config.num_predict_steps_train = 5
+
+  # Max prediction loops for prediction dataset.
+  config.num_predict_loops = 1
+  # Whether to use annotated number of operations to limit number of loops.
+  config.use_annotations = False
+  # Extra loops in addition to annotations.
+  config.extra_loops = 0
+  # Whether to copy input to prediction
+  config.copy_input = False
+  config.copy_input_in_full = False
+  # Whether to copy previous output
+  config.copy_output = False
+
+  config.end_token = '[END]'
+  config.in_out_token = '[SEP2]'
+  config.sep_token = '[SEP]'
+  config.end_iter_token = '[ENDITER]'
+
+  # Base learning rate.
+  config.learning_rate = 0.0625
+
+  # Linear learning rate warmup.
+  config.warmup_steps = 4000
+
+  # Cross entropy loss label smoothing.
+  config.label_smoothing = 0.1
+
+  # Decay factor for AdamW style weight decay.
+  config.weight_decay = 0.0
+
+  # Maximum length cutoff for training examples.
+  config.max_target_length = 84
+  # Maximum length cutoff for eval examples.
+  config.max_eval_target_length = 160
+  # Maximum length cutoff for predicted tokens.
+  config.max_predict_length = 160
+  # Inputs and targets share embedding.
+  config.share_embeddings = True
+
+  # Final logit transform uses embedding matrix transpose.
+  config.logits_via_embedding = True
+
+  # Number of transformer layers.
+  config.num_layers = 6
+
+  # Size of query/key/value for attention.
+  config.qkv_dim = 64
+  # Size of embeddings.
+  config.emb_dim = 64
+  # Size of the MLP.
+  config.mlp_dim = 256
+
+  # Number of attention heads.
+  config.num_heads = 4
+
+  # Dropout rate.
+  config.dropout_rate = 0.1
+
+  # Attention dropout rate.
+  config.attention_dropout_rate = 0.1
+
+  # Whether to save model checkpoints.
+  config.save_checkpoints = True
+  # Whether to restore from existing model checkpoints.
+  config.restore_checkpoints = True
+  # Just do prediction from saved checkpoint.
+  config.just_do_pred = True
+  # Save a checkpoint every these number of steps.
+  config.checkpoint_every_steps = 5_000
+  # Frequency of eval during training, e.g. every 1000 steps.
+  config.eval_every_steps = 1_250
+
+  # Use bfloat16 mixed precision training instead of float32.
+  config.use_bfloat16 = True
+
+  # Integer for PRNG random seed.
+  config.seed = 0
+
+  return config

--- a/model/configs/default_pcfg.py
+++ b/model/configs/default_pcfg.py
@@ -61,7 +61,17 @@ def get_config():
   # Whether to use annotated number of operations to limit number of loops.
   config.use_annotations = True
   # Extra loops in addition to annotations.
-  config.extra_loops = 2
+  config.extra_loops = 0
+  # Whether to copy input to prediction
+  config.copy_input = False
+  config.copy_input_in_full = False
+  # Whether to copy previous output
+  config.copy_output = False
+
+  config.end_token = None
+  config.in_out_token = None
+  config.sep_token = None
+  config.end_iter_token = 'END'
 
   # Base learning rate.
   config.learning_rate = 0.0625
@@ -111,10 +121,9 @@ def get_config():
   # Whether to restore from existing model checkpoints.
   config.restore_checkpoints = True
   # Just do prediction from saved checkpoint.
-  config.just_do_pred = True
-
+  config.just_do_pred = False
   # Save a checkpoint every these number of steps.
-  config.checkpoint_every_steps = 5_000
+  config.checkpoint_every_steps = 2_500
   # Frequency of eval during training, e.g. every 1000 steps.
   config.eval_every_steps = 1_250
 

--- a/model/configs/default_pcfg.py
+++ b/model/configs/default_pcfg.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Flax Authors.
+# Copyright 2021 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ def get_config():
   config.end_token = None
   config.in_out_token = None
   config.sep_token = None
-  config.end_iter_token = 'END'
+  config.end_iter_token = "END"
 
   # Base learning rate.
   config.learning_rate = 0.0625

--- a/model/input_pipeline.py
+++ b/model/input_pipeline.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-"""Input pipeline for a PCFG dataset."""
+"""Input pipeline."""
 
 import os
 from typing import Dict, Optional, List, Union
@@ -40,7 +40,7 @@ class NormalizeFeatureNamesOp:
 
 def get_raw_dataset(dataset_builder: tfds.core.DatasetBuilder,
                     split: str) -> tf.data.Dataset:
-  """Loads a raw PCFG dataset and normalizes feature keys.
+  """Loads a raw dataset and normalizes feature keys.
 
   Args:
     dataset_builder: TFDS dataset builder that can build `slit`.
@@ -257,7 +257,7 @@ def _pack_with_tf_ops(dataset: tf.data.Dataset, keys: List[str],
 # -----------------------------------------------------------------------------
 # Main dataset prep routines.
 # -----------------------------------------------------------------------------
-def preprocess_pcfg_data(dataset,
+def preprocess_data(dataset,
                         shuffle: bool,
                         num_epochs: Optional[int] = 1,
                         pack_examples: bool = True,
@@ -285,7 +285,7 @@ def preprocess_pcfg_data(dataset,
   dataset = dataset.repeat(num_epochs)
 
   if pack_examples:
-    dataset = pack_dataset(dataset, max_length, keys = ['inputs', 'targets'])
+    dataset = pack_dataset(dataset, max_length, keys = ["inputs", "targets"])
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
   else:  # simple (static-shape) padded batching
     dataset = dataset.padded_batch(
@@ -308,13 +308,13 @@ def preprocess_pcfg_data(dataset,
   return dataset
 
 
-def get_pcfg_datasets(config: ml_collections.ConfigDict,
+def get_datasets(config: ml_collections.ConfigDict,
                      *,
                      n_devices: int,
                      vocab_path: Optional[str] = None):
   """Load and return dataset of batched examples for use during training."""
   if vocab_path is None:
-    vocab_path = os.path.expanduser('~/pcfg_sentencepiece_model')
+    vocab_path = os.path.expanduser("~/sentencepiece_model")
 
   train_ds_builder = tfds.builder(config.dataset_name)
   
@@ -349,7 +349,7 @@ def get_pcfg_datasets(config: ml_collections.ConfigDict,
 
   batch_size = config.per_device_batch_size * n_devices
 
-  train_ds = preprocess_pcfg_data(
+  train_ds = preprocess_data(
       train_data,
       shuffle=True,
       num_epochs=None,
@@ -357,14 +357,14 @@ def get_pcfg_datasets(config: ml_collections.ConfigDict,
       batch_size=batch_size,
       max_length=config.max_target_length)
       
-  eval_train_ds = preprocess_pcfg_data(
+  eval_train_ds = preprocess_data(
       train_data,
       shuffle=False,
       pack_examples=False,
       batch_size=batch_size,
       max_length=config.max_eval_target_length)
       
-  predict_train_ds = preprocess_pcfg_data(
+  predict_train_ds = preprocess_data(
       train_data,
       shuffle=False,
       pack_examples=False,
@@ -372,14 +372,14 @@ def get_pcfg_datasets(config: ml_collections.ConfigDict,
       max_length=config.max_predict_length,
       drop_remainder=False)
 
-  eval_ds = preprocess_pcfg_data(
+  eval_ds = preprocess_data(
       eval_data,
       shuffle=False,
       pack_examples=False,
       batch_size=batch_size,
       max_length=config.max_eval_target_length)
 
-  predict_ds = preprocess_pcfg_data(
+  predict_ds = preprocess_data(
       predict_data,
       shuffle=False,
       pack_examples=False,

--- a/model/main.py
+++ b/model/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Main file for running the PCFG example.
+"""Main file for running the iterative decoding example.
 
 This file is intentionally kept short. The majority for logic is in libraries
 than can be easily tested and imported in Colab.

--- a/model/train.py
+++ b/model/train.py
@@ -405,7 +405,7 @@ def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
   """Processes the `predict_ds` and calculates the sentence accuracy from 
   decoded predictions."""
   
-  def concatenate_input(predicted):
+  def concatenate_input(this_input, concatenated_predicted, predicted):
     concatenated_input = []
     for i in range(n_devices):
         concatenated_input_2 = []
@@ -483,7 +483,8 @@ def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
     count = 0
     while count < max_predict_loops - 1: 
         if copy_input:
-            concatenated_input = concatenate_input(predicted)
+            concatenated_input = concatenate_input(this_input, concatenated_predicted, 
+                                                   predicted) 
             predicted = jnp.array(concatenated_input)
             
         predicted = p_pred_step(predicted, target, cache, decode.EOS_ID,
@@ -529,7 +530,7 @@ def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
                len(predictions), len(references), len(sources))
 
   # Calculate sentence accuracy for processed instructions against reference.
-  complete_matches = bleu.compute_complete_matches(references,predictions)
+  complete_matches = bleu.compute_complete_matches(references, predictions)
   all_complete_matches = per_host_sum_pmap(complete_matches)
   score = all_complete_matches[0] / all_complete_matches[1]
   # Save (wrongly predicted) samples for tensorboard.


### PR DESCRIPTION
In **train.py**, updated decode_and_calculate_acc to process cartesian data.

> Included flags: copy_input, copy_input_in_full, copy_output
> 
> 

> > copy_input indicates whether to copy previous prediction to next input.
> > copy_input_in_full indicates whether to copy only last prediction or all concatenated predictions up to this point.
> > copy_output indicates whether to concatenate the current prediction to the previous ones when saving the predictions at each predictions step; this is necessary to properly match predictions with targets.

> 
> Included arguments: end_token=None, in_out_token=None, sep_token=None, end_iter_token=None
> 
> >Different datasets will have different auxiliary tokens, so the tokens have to be given as input arguments to this function.

Updated **input_pipeline.py and main.py** to remove mentions to the PCFG dataset, as these scripts are common to all datasets.

Updated and renamed **default.py to default_pcfg.py**.

Created **default_cartesian.py**.
