### PR TITLE
luanaruiz9 test rel attn copy decoder

### DIFF
--- a/model/configs/default_pcfg.py
+++ b/model/configs/default_pcfg.py
@@ -1,0 +1,146 @@
+# Copyright 2021 The Flax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Default Hyperparameter configuration."""
+
+import ml_collections
+
+
+def get_config():
+  """Get the default hyperparameter configuration."""
+  config = ml_collections.ConfigDict()
+
+  # Path to load or store sentencepiece vocab file.
+  config.vocab_path = None
+
+  # Vocabulary size if `vocab_path` is not given.
+  config.vocab_size = 535
+  config.max_corpus_chars = 10**7
+
+  # Name of TFDS PCFG dataset to use.
+  config.dataset_name = "pcfg_systematicity_data"
+  config.train_split = "it_dec_train"
+
+  # Optional name of TFDS PCFG dataset to use for evaluation.
+  config.eval_dataset_name = None
+  config.eval_split = "it_dec_val"
+  config.predict_split = "it_dec_test"
+
+  # Per device batch size for training.
+  config.per_device_batch_size = 64
+
+  # Beam size for inference.
+  config.beam_size = 4
+
+  config.num_train_steps = 10_000
+
+  # Number of steps to take during evaluation.
+  config.num_eval_steps = 1
+  # Number of steps to generate predictions.
+  # -1 will use the whole eval dataset.
+  config.num_predict_steps = 5
+  # Number of steps to take during evaluation of training set.
+  config.num_eval_train_steps = 1
+  # Number of steps to generate predictions on the training set.
+  # -1 will use the whole training dataset.
+  config.num_predict_steps_train = 1
+
+  # Max prediction loops for prediction dataset.
+  config.num_predict_loops = 1
+  # Whether to use annotated number of operations to limit number of loops.
+  config.use_annotations = True
+  # Extra loops in addition to annotations.
+  config.extra_loops = 0
+  # Whether to copy input to prediction
+  config.copy_input = False
+  config.copy_input_in_full = False
+  # Whether to copy previous output
+  config.copy_output = False
+
+  config.end_token = None
+  config.in_out_token = None
+  config.sep_token = None
+  config.end_iter_token = 'END'
+
+  # Base learning rate.
+  config.learning_rate = 0.0625
+
+  # Linear learning rate warmup.
+  config.warmup_steps = 4000
+
+  # Cross entropy loss label smoothing.
+  config.label_smoothing = 0.1
+
+  # Decay factor for AdamW style weight decay.
+  config.weight_decay = 0.0
+
+  # Maximum length cutoff for training examples.
+  config.max_target_length = 100
+  # Maximum length cutoff for eval examples.
+  config.max_eval_target_length = 100
+  # Maximum length cutoff for predicted tokens.
+  config.max_predict_length = 100
+  # Inputs and targets share embedding.
+  config.share_embeddings = True
+
+  # Final logit transform uses embedding matrix transpose.
+  config.logits_via_embedding = True
+
+  # Number of transformer layers.
+  config.num_layers = 6
+
+  # Size of query/key/value for attention.
+  config.qkv_dim = 64
+  # Size of embeddings.
+  config.emb_dim = 64
+  # Size of the MLP.
+  config.mlp_dim = 256
+
+  # Number of attention heads.
+  config.num_heads = 4
+
+  # Sinusoidal absolute positional encodings.
+  config.sinusoidal = False
+  # Relative radius
+  config.relative_radius = 8 # or 'None' for no relative attention
+  config.relative_bias = True
+  config.enc2dec = True
+  
+  # Copy decoder layers.
+  config.copy_decoder = False
+
+  # Dropout rate.
+  config.dropout_rate = 0.1
+
+  # Attention dropout rate.
+  config.attention_dropout_rate = 0.1
+
+  # Whether to save model checkpoints.
+  config.save_checkpoints = True
+  # Whether to restore from existing model checkpoints.
+  config.restore_checkpoints = True
+  # Just do prediction from saved checkpoint.
+  config.just_do_pred = False
+  # Save a checkpoint every these number of steps.
+  config.checkpoint_every_steps = 5_000
+  # Frequency of eval during training, e.g. every 1000 steps.
+  config.eval_every_steps = 1_250
+
+  # Use bfloat16 mixed precision training instead of float32.
+  config.use_bfloat16 = True
+
+  # Integer for PRNG random seed.
+  config.seed = 0
+
+  return config

--- a/model/input_pipeline.py
+++ b/model/input_pipeline.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-"""Input pipeline for a PCFG dataset."""
+"""Input pipeline."""
 
 import os
 from typing import Dict, Optional, List, Union
@@ -40,7 +40,7 @@ class NormalizeFeatureNamesOp:
 
 def get_raw_dataset(dataset_builder: tfds.core.DatasetBuilder,
                     split: str) -> tf.data.Dataset:
-  """Loads a raw PCFG dataset and normalizes feature keys.
+  """Loads a raw dataset and normalizes feature keys.
 
   Args:
     dataset_builder: TFDS dataset builder that can build `slit`.
@@ -257,7 +257,7 @@ def _pack_with_tf_ops(dataset: tf.data.Dataset, keys: List[str],
 # -----------------------------------------------------------------------------
 # Main dataset prep routines.
 # -----------------------------------------------------------------------------
-def preprocess_pcfg_data(dataset,
+def preprocess_data(dataset,
                         shuffle: bool,
                         num_epochs: Optional[int] = 1,
                         pack_examples: bool = True,
@@ -285,7 +285,7 @@ def preprocess_pcfg_data(dataset,
   dataset = dataset.repeat(num_epochs)
 
   if pack_examples:
-    dataset = pack_dataset(dataset, max_length, keys = ['inputs', 'targets'])
+    dataset = pack_dataset(dataset, max_length, keys = ["inputs", "targets"])
     dataset = dataset.batch(batch_size, drop_remainder=drop_remainder)
   else:  # simple (static-shape) padded batching
     dataset = dataset.padded_batch(
@@ -308,13 +308,13 @@ def preprocess_pcfg_data(dataset,
   return dataset
 
 
-def get_pcfg_datasets(config: ml_collections.ConfigDict,
+def get_datasets(config: ml_collections.ConfigDict,
                      *,
                      n_devices: int,
                      vocab_path: Optional[str] = None):
   """Load and return dataset of batched examples for use during training."""
   if vocab_path is None:
-    vocab_path = os.path.expanduser('~/pcfg_sentencepiece_model')
+    vocab_path = os.path.expanduser('~/sentencepiece_model')
 
   train_ds_builder = tfds.builder(config.dataset_name)
   
@@ -349,22 +349,22 @@ def get_pcfg_datasets(config: ml_collections.ConfigDict,
 
   batch_size = config.per_device_batch_size * n_devices
 
-  train_ds = preprocess_pcfg_data(
+  train_ds = preprocess_data(
       train_data,
       shuffle=True,
       num_epochs=None,
-      pack_examples=True,
+      pack_examples=False,
       batch_size=batch_size,
       max_length=config.max_target_length)
       
-  eval_train_ds = preprocess_pcfg_data(
+  eval_train_ds = preprocess_data(
       train_data,
       shuffle=False,
       pack_examples=False,
       batch_size=batch_size,
       max_length=config.max_eval_target_length)
       
-  predict_train_ds = preprocess_pcfg_data(
+  predict_train_ds = preprocess_data(
       train_data,
       shuffle=False,
       pack_examples=False,
@@ -372,14 +372,14 @@ def get_pcfg_datasets(config: ml_collections.ConfigDict,
       max_length=config.max_predict_length,
       drop_remainder=False)
 
-  eval_ds = preprocess_pcfg_data(
+  eval_ds = preprocess_data(
       eval_data,
       shuffle=False,
       pack_examples=False,
       batch_size=batch_size,
       max_length=config.max_eval_target_length)
 
-  predict_ds = preprocess_pcfg_data(
+  predict_ds = preprocess_data(
       predict_data,
       shuffle=False,
       pack_examples=False,

--- a/model/train.py
+++ b/model/train.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PCFG example.
+"""Iterative decoding example.
 
-This script trains a Transformer on a PCFG dataset.
+This script trains a Transformer on an iterative decoding dataset.
 """
 
 # pytype: disable=wrong-arg-count
@@ -285,7 +285,7 @@ def predict_step(inputs,
                  eos_id,
                  max_decode_len,
                  config,
-                 beam_size=4):
+                 beam_size=None):
   """Predicts translation with fast decoding beam search on a batch."""
   # Prepare transformer fast-decoder call for beam search: for beam search, we
   # need to set up our decoder model to handle a batch size equal to
@@ -397,8 +397,11 @@ def evaluate(*, p_eval_step, target, eval_ds: tf.data.Dataset,
 def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
                                  predict_ds: tf.data.Dataset, decode_tokens,
                                  encode_tokens, max_predict_length: int, 
-                                 max_predict_loops = 1, use_annotations = False,
-                                 extra_loops = 0):
+                                 max_predict_loops=1, use_annotations=False,
+                                 extra_loops=0, copy_input=False,  
+                                 copy_input_in_full=False, copy_output=False,
+                                 end_token=None, in_out_token=None,
+                                 sep_token=None, end_iter_token=None):
   """Processes the `predict_ds` and calculates the sentence accuracy from 
   decoded predictions."""
   n_devices = jax.local_device_count()
@@ -406,51 +409,110 @@ def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
   sources, references, predictions = [], [], []
   wrong_preds, wrong_refs, wrong_sources = [], [], []
   predicted_list_all_batches = []
+  
   for pred_batch in predict_ds:
     pred_batch = jax.tree_map(lambda x: x._numpy(), pred_batch)  # pylint: disable=protected-access
     # Handle final odd-sized batch by padding instead of dropping it.
     cur_pred_batch_size = pred_batch["inputs"].shape[0]
+    per_dev_batch_size = int(cur_pred_batch_size / n_devices)
     if cur_pred_batch_size % n_devices:
-      padded_size = int(np.ceil(cur_pred_batch_size / n_devices) * n_devices)
+      per_dev_batch_size = int(np.ceil(cur_pred_batch_size / n_devices))
+      padded_size = int(per_dev_batch_size * n_devices)
       pred_batch = jax.tree_map(
           lambda x: pad_examples(x, padded_size),  # pylint: disable=cell-var-from-loop
           pred_batch)
     pred_batch = common_utils.shard(pred_batch)
     cache = p_init_cache(pred_batch["inputs"])
-    count = 0
     predicted = p_pred_step(pred_batch['inputs'], target, cache, decode.EOS_ID,
                             max_predict_length)
-    predicted_list = [tohost(predicted)]
+    concatenated_predicted = predicted
+    predicted_list = [tohost(concatenated_predicted)]
+    this_input = pred_batch["inputs"]
+    
     if use_annotations:
         max_predict_loops = jnp.max(pred_batch['op']) + extra_loops
+        
+    count = 0
     while count < max_predict_loops - 1: 
+        if copy_input:
+            concatenated_input = []
+            for i in range(n_devices):
+                concatenated_input_2 = []
+                for j in range(per_dev_batch_size):
+                    total_length = len(predicted[i][j])
+                    # concatenate [input with END removed, '[SEP2]', and output with 
+                    # '[START]' removed]
+                    encoded_end_token = encode_tokens(end_token)[0]
+                    idx = jnp.argwhere(this_input[i][j] == encoded_end_token)[0][0]
+                    modified_input = this_input[i][j][:idx]
+                    length = total_length - len(modified_input)
+                    encoded_sep2_token = encode_tokens(in_out_token)[:-1].numpy()
+                    if not copy_input_in_full:
+                        new_input = jnp.concatenate([encoded_sep2_token, predicted[i][j][1:length]])
+                    else:
+                        new_input = jnp.concatenate([encoded_sep2_token, concatenated_predicted[i][j][1:length]])
+                    new_input = jnp.concatenate([modified_input, new_input]) 
+                    concatenated_input_2.append(new_input)
+                concatenated_input.append(concatenated_input_2)
+            predicted = jnp.array(concatenated_input)
+            
         predicted = p_pred_step(predicted, target, cache, decode.EOS_ID,
                             max_predict_length)
+                            
+        if not copy_output:
+            concatenated_predicted = predicted 
+        else:
+            previous_conc_pred = concatenated_predicted
+            concatenated_predicted = []
+            for i in range(n_devices):
+                concatenated_predicted_2 = []
+                for j in range(per_dev_batch_size):
+                    total_length = len(previous_conc_pred[i][j])
+                    # concatenate [previous output with END removed, '[SEP]', 
+                    # current output with '[START]' removed]
+                    encoded_end_token = encode_tokens(end_token)[0]
+                    if encoded_end_token in previous_conc_pred[i][j]:
+                        idx = jnp.min(jnp.argwhere(previous_conc_pred[i][j] == encoded_end_token))
+                        modified_conc_pred = previous_conc_pred[i][j][:idx]
+                        length = total_length - len(modified_conc_pred)
+                        encoded_sep_token = encode_tokens(sep_token)[:-1].numpy()
+                        new_conc_pred = jnp.concatenate([encoded_sep_token, predicted[i][j][1:length]])
+                        new_conc_pred = jnp.concatenate([modified_conc_pred, new_conc_pred])
+                    else:
+                        new_conc_pred = predicted[i][j]
+                    concatenated_predicted_2.append(new_conc_pred)
+                concatenated_predicted.append(concatenated_predicted_2)
+            concatenated_predicted = jnp.array(concatenated_predicted)
+                    
         count += 1
-        predicted_list.append(tohost(predicted))
+        predicted_list.append(tohost(concatenated_predicted))
+    
     inputs = tohost(pred_batch["inputs"])
     targets = tohost(pred_batch["targets"])
+    
     # Iterate through non-padding examples of batch.
-    for i in range(cur_pred_batch_size):
+    for m in range(cur_pred_batch_size):
       stop = False
-      for j in range(max_predict_loops):
-          predicted = predicted_list[j]
-          if j == 0:
-            sources.append(decode_tokens(inputs[i]))
-            references.append(decode_tokens(targets[i]))
-          if 'END' in decode_tokens(predicted[i]) and not stop:
+      for n in range(max_predict_loops):
+          predicted = predicted_list[n]
+          if n == 0:
+            sources.append(decode_tokens(inputs[m]))
+            references.append(decode_tokens(targets[m]))
+          if end_iter_token in decode_tokens(predicted[m]) and not stop:
             stop = True
-            predictions.append(decode_tokens(predicted[i]))
-          if j == max_predict_loops - 1 and not stop:
-             predictions.append(decode_tokens(predicted[i]))
-      if not references[i] == predictions[i]:
-          wrong_preds.append(predictions[i])
-          wrong_refs.append(references[i])
-          wrong_sources.append(sources[i])
+            predictions.append(decode_tokens(predicted[m]))
+          if n == max_predict_loops - 1 and not stop:
+            predictions.append(decode_tokens(predicted[m]))
+      if not references[m] == predictions[m]:
+          wrong_preds.append(predictions[m])
+          wrong_refs.append(references[m])
+          wrong_sources.append(sources[m])
+          
     new_predicted_list = []
     for array in predicted_list:
       new_predicted_list.append(list(array))
     predicted_list_all_batches.append(new_predicted_list)  
+    
   logging.info("Translation: %d predictions %d references %d sources.",
                len(predictions), len(references), len(sources))
 
@@ -460,8 +522,9 @@ def decode_and_calculate_acc(*, p_pred_step, p_init_cache, target, config,
   score = all_complete_matches[0] / all_complete_matches[1]
   # Save (wrongly predicted) samples for tensorboard.
   exemplars = ""
-  for n in np.random.choice(np.arange(len(wrong_preds)), 12):
-    exemplars += f"{wrong_sources[n]}\n\n{wrong_refs[n]}\n\n{wrong_preds[n]}\n\n"
+  if len(wrong_preds) > 0:
+    for n in np.random.choice(np.arange(len(wrong_preds)), 12):
+        exemplars += f"{wrong_sources[n]}\n\n{wrong_refs[n]}\n\n{wrong_preds[n]}\n\n"
   out_predictions = jax.tree_map(lambda x: decode_tokens(x), predicted_list_all_batches)
   return exemplars, score, out_predictions
 
@@ -485,7 +548,7 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
   # Load Dataset
   # ---------------------------------------------------------------------------
   logging.info("Initializing dataset.")
-  train_ds, eval_train_ds, predict_train_ds, eval_ds, predict_ds, encoder = input_pipeline.get_pcfg_datasets(
+  train_ds, eval_train_ds, predict_train_ds, eval_ds, predict_ds, encoder = input_pipeline.get_datasets(
       n_devices=jax.local_device_count(),
       config=config,
       vocab_path=vocab_path)
@@ -528,7 +591,12 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
       deterministic=False,
       decode=False,
       kernel_init=nn.initializers.xavier_uniform(),
-      bias_init=nn.initializers.normal(stddev=1e-6))
+      bias_init=nn.initializers.normal(stddev=1e-6),
+      sinusoidal=config.sinusoidal,
+      relative_radius=config.relative_radius,
+      relative_bias=config.relative_bias,
+      enc2dec=config.enc2dec,
+      copy_decoder=config.copy_decoder)
   eval_config = train_config.replace(deterministic=True)
   predict_config = train_config.replace(deterministic=True, decode=True)
 
@@ -617,7 +685,14 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
       max_predict_length=config.max_predict_length,
       max_predict_loops=config.num_predict_loops,
       use_annotations=config.use_annotations,
-      extra_loops=config.extra_loops)
+      extra_loops=config.extra_loops,
+      copy_input=config.copy_input,
+      copy_input_in_full=config.copy_input_in_full,
+      copy_output=config.copy_output,
+      end_token=config.end_token, 
+      in_out_token=config.in_out_token,
+      sep_token=config.sep_token, 
+      end_iter_token=config.end_iter_token)
       writer.write_scalars(0, {"pred_test_accuracy": test_acc})
       writer.write_texts(0, {"samples": exemplars})
       # Log list of predictions
@@ -685,7 +760,11 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
                   decode_tokens=decode_tokens,
                   encode_tokens=encode_tokens,
                   max_predict_length=config.max_predict_length,
-                  max_predict_loops=1)
+                  max_predict_loops=1,
+                  end_token=config.end_token, 
+                  in_out_token=config.in_out_token,
+                  sep_token=config.sep_token, 
+                  end_iter_token=config.end_iter_token)
               writer.write_scalars(step, {"pred_train_acc": train_acc})
               writer.write_texts(step, {"samples": exemplars})
                
@@ -710,7 +789,14 @@ def train_and_evaluate(config: ml_collections.ConfigDict, workdir: str):
                   max_predict_length=config.max_predict_length,
                   max_predict_loops=config.num_predict_loops,
                   use_annotations=config.use_annotations,
-                  extra_loops=config.extra_loops)
+                  extra_loops=config.extra_loops,
+                  copy_input=config.copy_input,
+                  copy_input_in_full=config.copy_input_in_full,
+                  copy_output=config.copy_output,
+                  end_token=config.end_token, 
+                  in_out_token=config.in_out_token,
+                  sep_token=config.sep_token, 
+                  end_iter_token=config.end_iter_token)
               writer.write_scalars(step, {"pred_test_accuracy": test_acc})
               writer.write_texts(step, {"samples": exemplars})
               # Log list of predictions


### PR DESCRIPTION
Santi, Josh,

Can you please have a look at my implementation of relative attention and of the copy decoder? The main changes are in models.py. The changes in train.py and in the configs file refer to new config variables/flags and in input_pipeline.py I disabled dataset packing in the training set, as I believe that would interfere with the current implementation of relative attention.

Presently, I am not able to properly learn models with relative attention. I believe that there is something wrong with this implementation as training stalls at around 30% token-level accuracy and 0% sentence-level accuracy. 

Here is an example of error (with relative attention only, relative radius 16) that I thought was curious as most of the tokens are correct but the order is wrong.

remove_first echo G16 L3 E5 W8 , T3 A8 E3 (input)

remove_first G16 L3 E5 W8 W8 , T3 A8 E3 (target)

remove_first A8 T3 W8 , E5 G16 E3 L3 (prediction)

As for the copy decoder, the biggest difference with the keras implementation is that the softmax of the logits is not calculated in the transformer (models.py), but in train.py, so it is the output of the decoder and of the copy decoder that are being mixed.

Thanks!
 